### PR TITLE
Fix bug that classes "mobile portrait" was apply to desktop

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -159,7 +159,11 @@
     
     <script type="text/javascript">
       console.log("device.portrait() === %s", device.portrait());
+	  try{
       console.log("device.landscape() === %s", device.landscape());
+	  } catch(e){
+		console.log("cant handle orientation: ", e);
+	  }
       console.log("device.mobile() === %s", device.mobile());
       console.log("device.tablet() === %s", device.tablet());
       console.log("device.ipad() === %s", device.ipad());

--- a/lib/device.js
+++ b/lib/device.js
@@ -77,6 +77,8 @@
   };
 
   device.landscape = function() {
+	if (typeof window.orientation == "undefined")
+		throw new Error("Cant handle orientation");
     if (Math.abs(window.orientation === 90)) {
       return true;
     } else {
@@ -133,21 +135,28 @@
   } else if (device.windows()) {
     if (device.windowsTablet()) {
       _addClass("windows tablet");
-    } else {
+    } else if (device.windowsPhone()){
       _addClass("windows mobile");
-    }
+    } else {
+		_addClass("windows desktop");
+	}
   } else {
     _addClass("desktop");
   }
 
   _handleOrientation = function() {
-    if (device.landscape()) {
-      _removeClass("portrait");
-      return _addClass("landscape");
-    } else {
-      _removeClass("landscape");
-      return _addClass("portrait");
-    }
+	try{
+		if (device.landscape()) {
+		  _removeClass("portrait");
+		  return _addClass("landscape");
+		} else {
+		  _removeClass("landscape");
+		  return _addClass("portrait");
+		}
+	}
+	catch(e){
+		//cant handle orientation on this device because window.orientation is undefined
+	}
   };
 
   _supports_orientation = __indexOf.call(window, "onorientationchange") >= 0;


### PR DESCRIPTION
Classes "mobile portrait" no more applying. Function device.landskape
now throws exception if window.orientation is undefined
