### PR TITLE
Update device.coffee

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -38,7 +38,7 @@ device.androidTablet = ->
   device.android() and not _find 'mobile'
 
 device.blackberry = ->
-  _find 'blackberry' or _find 'bb10' or _find 'rim'
+  _find('blackberry') or _find('bb10') or _find('rim')
 
 device.blackberryPhone = ->
   device.blackberry() and not _find 'tablet'


### PR DESCRIPTION
The desire to write less code is commendable, but unfortunately, sometimes result in wrong JS.

``` coffeescript
_find 'blackberry' or _find 'bb10' or _find 'rim'
# _find('blackberry' || _find('bb10' || _find('rim')));

_find('blackberry') or _find('bb10') or _find('rim')
# _find('blackberry') || _find('bb10') || _find('rim');
```
