### PR TITLE
Fixed detection of orientation support

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -157,7 +157,7 @@ _handleOrientation = ->
 
 # Detect whether device supports orientationchange event,
 # otherwise fall back to the resize event.
-_supports_orientation = "onorientationchange" in window
+_supports_orientation = "onorientationchange" of window
 _orientation_event = if _supports_orientation then "orientationchange" else "resize"
 
 # Listen for changes in orientation.


### PR DESCRIPTION
Hi,

Your use of CoffeeScript's `in` keyword while detecting orientation support generates an __indexOf() search for "orientationchange" in the window object. I assume this is not what you intended - therefore I changed it to

``` coffeescript
_supports_orientation = "onorientationchange" of window
```

Which translates to (JavaScript):

``` javascript
var _supports_orientation;
_supports_orientation = "onorientationchange" in window;
```

This will also cut down the size of the JavaScript a bit because the generated __indexOf method is no longer needed in the JS file.
