### PR TITLE
meego mobile detection

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -63,7 +63,7 @@ device.windowsTablet = ->
   device.windows() and _find 'touch'
 
 device.fxos = ->
-  _find('(mobile; rv:') or _find('(tablet; rv:')
+  (_find('(mobile;') or _find('(tablet;')) and _find('; rv:')
 
 device.fxosPhone = ->
   device.fxos() and _find 'mobile'


### PR DESCRIPTION
Added support for MeeGo OS, used by the Nokia N9 phone

User-agent string is "Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13"

https://bugzilla.mozilla.org/show_bug.cgi?id=682969
