### PR TITLE
Add node webkit detection

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -70,9 +70,12 @@ device.fxosPhone = ->
 
 device.fxosTablet = ->
   device.fxos() and _find 'tablet'
-  
+
 device.meego = ->
   _find 'meego'
+
+device.nodeWebkit = ->
+  typeof window.process == 'object'
 
 device.mobile = ->
   device.androidPhone() or device.iphone() or device.ipod() or device.windowsPhone() or device.blackberryPhone() or device.fxosPhone() or device.meego()
@@ -155,7 +158,10 @@ else if device.fxos()
 
 else if device.meego()
   _addClass "meego mobile"
-	
+
+else if device.nodeWebkit()
+  _addClass "node-webkit"
+
 else
   _addClass "desktop"
 


### PR DESCRIPTION
should close #51 

node webkit add a `process` global object which contains a lot of information.
`process.versions['node-webkit']` contains node webkit version and can also be tested if someday another tool expose a `process` variable.

see:
- https://gist.github.com/thcreate/5771471
- https://github.com/bestiejs/platform.js/issues/18
- http://stackoverflow.com/questions/13726877/target-node-webkit-browser-using-jquery
