### PR TITLE
Add cordova detection

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -70,9 +70,12 @@ device.fxosPhone = ->
 
 device.fxosTablet = ->
   device.fxos() and _find 'tablet'
-  
+
 device.meego = ->
   _find 'meego'
+
+device.cordova = ->
+  window.cordova && location.protocol == 'file:'
 
 device.mobile = ->
   device.androidPhone() or device.iphone() or device.ipod() or device.windowsPhone() or device.blackberryPhone() or device.fxosPhone() or device.meego()
@@ -155,9 +158,12 @@ else if device.fxos()
 
 else if device.meego()
   _addClass "meego mobile"
-	
+
 else
   _addClass "desktop"
+
+if device.cordova()
+  _addClass "cordova"
 
 
 # Orientation Handling


### PR DESCRIPTION
should fix #53

Since 1.7 `cordova` is exposed instead of phonegap. 2nd secure test is that protocol is `file:` but should not be used alone because a user can open a file with its own browser too.

cordova could be use on a lot of device and in many case preserve original UA so I kept the `_addClass` outside the if else logic to be able to detect both ios & cordova for example.
