### PR TITLE
Check whether device is desktop

### DIFF
--- a/src/device.coffee
+++ b/src/device.coffee
@@ -81,7 +81,7 @@ device.tablet = ->
   device.ipad() or device.androidTablet() or device.blackberryTablet() or device.windowsTablet() or device.fxosTablet()
 
 device.desktop = ->
-  !device.mobile( ) and !device.tablet()
+  !device.mobile() and !device.tablet()
 
 device.portrait = ->
   Math.abs(window.orientation) isnt 90


### PR DESCRIPTION
Simple shorthand function to check whether the device is a desktop (i.e not mobile and not tablet). Useful JavaScript condition
