### PR TITLE
Fixes Windows tablet detection.

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -58,7 +58,7 @@
   };
 
   device.windowsTablet = function() {
-    return device.windows() && _find('touch');
+    return device.windows() && (_find('touch') && !device.windowsPhone());
   };
 
   device.fxos = function() {

--- a/src/device.coffee
+++ b/src/device.coffee
@@ -60,7 +60,7 @@ device.windowsPhone = ->
   device.windows() and _find 'phone'
 
 device.windowsTablet = ->
-  device.windows() and _find 'touch'
+  device.windows() and (_find('touch') and not device.windowsPhone())
 
 device.fxos = ->
   (_find('(mobile;') or _find('(tablet;')) and _find('; rv:')


### PR DESCRIPTION
Using the example provided in the repo and the latest version of device.js (0.1.59) Windows Phone 8 devices are incorrectly detected as "tablet" rather than "mobile". 

I've confirmed this issue on an actual device as well as in the emulator (availble in the [Visual Studio 2013 Express for Windows](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-8) download).

This fix updates the `windowsTablet()` method with an additional check to ensure the device is not a phone. The `windowsTablet()` function now looks like this:

``` coffeescript
device.windowsTablet = ->
  device.windows() and (_find('touch') and not device.windowsPhone())
```
