### PR TITLE
IE8 doesn't support hasOwnProperty on window object

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -271,7 +271,7 @@
 
   // Detect whether device supports orientationchange event,
   // otherwise fall back to the resize event.
-  if (window.hasOwnProperty("onorientationchange")) {
+  if (Object.prototype.hasOwnProperty.call(window, "onorientationchange")) {
     orientationEvent = "orientationchange";
   } else {
     orientationEvent = "resize";


### PR DESCRIPTION
IE8 doesn't support the hasOwnProperty on the window object, so this change leverages the Object prototype method to perform the same call, without the IE8 script error.