### PR TITLE
docs: remove Node >= 22 requirement, add CDN usage to README

### DIFF
--- a/.changeset/fix-readme-engines.md
+++ b/.changeset/fix-readme-engines.md
@@ -1,0 +1,5 @@
+---
+"current-device": patch
+---
+
+Remove Node.js >= 22 requirement for consumers (lowered to >= 16). Add CDN script tag usage docs to README.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This is a widely-used public package. Follow semver strictly: breaking changes r
 
 - TypeScript strict mode — no `any` types
 - pnpm as package manager (esbuild must be in pnpm.onlyBuiltDependencies)
-- Node.js >= 22
+- Node.js >= 16 (for consumers; development requires Node 22)
 - Dual CJS/ESM via package.json exports field
 - CI: GitHub Actions (.github/workflows/ci.yml)
 - Releases: Changesets (.changeset/) — run `pnpm changeset` to describe changes, the release.yml workflow handles versioning and npm publish on merge to main

--- a/README.md
+++ b/README.md
@@ -44,14 +44,6 @@ Just include the script. The script then updates the `<html>` section with the
 
 ## Installation
 
-Requires **Node.js >= 22**.
-
-```sh
-pnpm add current-device
-```
-
-Or with npm:
-
 ```sh
 npm install current-device
 ```
@@ -64,6 +56,17 @@ import device from "current-device";
 
 // CommonJS
 const device = require("current-device").default;
+```
+
+### CDN / Script Tag
+
+You can also include current-device directly via a `<script>` tag using a CDN:
+
+```html
+<script src="https://unpkg.com/current-device/dist/index.global.js"></script>
+<script>
+  console.log(device.type); // 'mobile', 'tablet', or 'desktop'
+</script>
 ```
 
 ### TypeScript

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "packageManager": "pnpm@10.30.1",
   "engines": {
-    "node": ">=22"
+    "node": ">=16"
   },
   "author": {
     "name": "Matthew Hudson",


### PR DESCRIPTION
## Summary
- Remove misleading "Requires Node.js >= 22" from README — this is a browser library, consumers don't need Node 22
- Lower `engines.node` from `>=22` to `>=16` so users on Node 18/20 LTS aren't blocked on install
- Add CDN/script tag usage docs for the IIFE build added in v2.0.1
- Includes changeset for a patch release

## Test plan
- [x] `pnpm run test` — all 35 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — CJS + ESM + IIFE + .d.ts all built

🤖 Generated with [Claude Code](https://claude.com/claude-code)