### PR TITLE
feat: add HarmonyOS device detection

### DIFF
--- a/.changeset/harmonyos-detection.md
+++ b/.changeset/harmonyos-detection.md
@@ -1,0 +1,5 @@
+---
+"current-device": minor
+---
+
+Add HarmonyOS device detection via `device.harmonyos()`. HarmonyOS devices now get the `harmonyos` CSS class on `<html>` instead of `android`. Closes #375.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type DeviceOs =
   | 'fxos'
   | 'meego'
   | 'television'
+  | 'harmonyos'
   | 'unknown'
 
 export type OrientationChangeCallback = (newOrientation: 'landscape' | 'portrait') => void
@@ -35,6 +36,7 @@ export interface Device {
   fxosPhone(): boolean
   fxosTablet(): boolean
   meego(): boolean
+  harmonyos(): boolean
   television(): boolean
   cordova(): boolean
   nodeWebkit(): boolean
@@ -205,6 +207,10 @@ device.meego = function (): boolean {
   return find('meego')
 }
 
+device.harmonyos = function (): boolean {
+  return find('harmonyos')
+}
+
 device.cordova = function (): boolean {
   return !!(window as Window & { cordova?: unknown }).cordova && location.protocol === 'file:'
 }
@@ -307,6 +313,12 @@ if (device.ios()) {
   }
 } else if (device.macos()) {
   addClass('macos desktop')
+} else if (device.harmonyos()) {
+  if (find('mobile')) {
+    addClass('harmonyos mobile')
+  } else {
+    addClass('harmonyos tablet')
+  }
 } else if (device.android()) {
   if (device.androidTablet()) {
     addClass('android tablet')
@@ -406,6 +418,7 @@ device.os = findMatch([
   'iphone',
   'ipad',
   'ipod',
+  'harmonyos',
   'android',
   'blackberry',
   'macos',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -90,6 +90,9 @@ describe('current-device', () => {
       it('Exposes a `meego` function', () => {
         expect(typeof device.meego).toBe('function')
       })
+      it('Exposes a `harmonyos` function', () => {
+        expect(typeof device.harmonyos).toBe('function')
+      })
       it('Exposes a `cordova` function', () => {
         expect(typeof device.cordova).toBe('function')
       })

--- a/tests/ua-strings.ts
+++ b/tests/ua-strings.ts
@@ -216,6 +216,26 @@ export const uaFixtures: UAFixture[] = [
     },
   },
 
+  // === HarmonyOS ===
+  {
+    name: 'HarmonyOS phone (Huawei Browser)',
+    ua: 'Mozilla/5.0 (Linux; Android 10; HarmonyOS; ELS-AN10; HMSCore 6.0.0.306) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.93 HuaweiBrowser/11.1.2.301 Mobile Safari/537.36',
+    expected: {
+      os: 'harmonyos',
+      type: 'mobile',
+      methods: { harmonyos: true, android: true, androidPhone: true, mobile: true, tablet: false, desktop: false },
+    },
+  },
+  {
+    name: 'HarmonyOS tablet (Huawei Browser)',
+    ua: 'Mozilla/5.0 (Linux; Android 12; HarmonyOS; BRT-W09; HMSCore 6.14.0.322) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.196 HuaweiBrowser/15.0.9.300 Safari/537.36',
+    expected: {
+      os: 'harmonyos',
+      type: 'tablet',
+      methods: { harmonyos: true, android: true, androidTablet: true, tablet: true, mobile: false, desktop: false },
+    },
+  },
+
   // === Edge cases ===
   {
     name: 'Windows Phone',


### PR DESCRIPTION
## Summary

- Add `device.harmonyos()` method to detect Huawei HarmonyOS devices
- HarmonyOS detection is checked before Android since HarmonyOS UAs contain "Android" in the UA string
- Adds `harmonyos` CSS class to `<html>` element (instead of `android`)
- Adds `'harmonyos'` to `DeviceOs` type union

Closes #375

### Why before Android?

HarmonyOS user agents look like:
```
Mozilla/5.0 (Linux; Android 10; HarmonyOS; ELS-AN10; ...) ...
```

They contain "Android", so `device.android()` returns true. `device.harmonyos()` checks for "harmonyos" in the UA and is evaluated before Android in both the CSS class chain and the `findMatch` list, so `device.os` returns `'harmonyos'` (not `'android'`). Individual methods like `device.android()` and `device.androidPhone()` still return true for HarmonyOS devices.

### Depends on

This PR is based on #390 (UA test suite). Merge #390 first, then rebase this PR onto main.

## Test plan

- [x] All 171 tests pass (`pnpm run test`)
- [x] TypeScript compiles (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] 2 HarmonyOS fixtures (phone + tablet) included
- [x] API shape test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)