### PR TITLE
Expand device support and modernize DOM logic

### DIFF
--- a/.changeset/modernize-device-detection.md
+++ b/.changeset/modernize-device-detection.md
@@ -1,0 +1,11 @@
+---
+"current-device": minor
+---
+
+Expand device and OS support and modernize internal DOM logic.
+
+- Added detection for **visionOS** (Apple Vision Pro).
+- Added detection for **ChromeOS** and generic **Linux**.
+- Expanded **Television** detection to include modern Smart TV platforms (Tizen, webOS) and game consoles (PlayStation, Xbox, Nintendo).
+- Refactored internal DOM manipulation to use the modern `classList` API for better safety and performance.
+- Improved logic for existing detections to prevent false positives (e.g., excluding visionOS from macOS/iPadOS).

--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ This module inserts CSS classes into the `<html>` element.
 
 - iOS: iPhone, iPod, iPad
 - macOS
+- visionOS (Apple Vision Pro)
 - Android: Phones & Tablets
 - Blackberry: Phones & Tablets
 - Windows: Phones, Tablets, Desktops
+- ChromeOS
+- Linux
 - Firefox OS: Phones & Tablets
 
 ### USAGE
@@ -137,6 +140,18 @@ orientation.
 	<tr>
 		<td>Windows Desktop</td>
 		<td>windows desktop</td>
+	</tr>
+	<tr>
+		<td>visionOS</td>
+		<td>visionos tablet</td>
+	</tr>
+	<tr>
+		<td>ChromeOS</td>
+		<td>chromeos desktop</td>
+	</tr>
+	<tr>
+		<td>Linux</td>
+		<td>linux desktop</td>
 	</tr>
 	<tr>
 		<td>Firefox OS Phone</td>
@@ -274,6 +289,18 @@ write checks on the following device characteristics:
 		<td>device.meego()</td>
 	</tr>
 	<tr>
+		<td>visionOS</td>
+		<td>device.visionos()</td>
+	</tr>
+	<tr>
+		<td>ChromeOS</td>
+		<td>device.chromeos()</td>
+	</tr>
+	<tr>
+		<td>Linux</td>
+		<td>device.linux()</td>
+	</tr>
+	<tr>
 		<td>Television</td>
 		<td>device.television()</td>
 	</tr>
@@ -339,7 +366,7 @@ attribute without looping through all of its getter methods.
 	<tr>
 		<td>device.os</td>
 		<td>DeviceOs</td>
-		<td>'ios', 'iphone', 'ipad', 'ipod', 'android', 'blackberry', 'windows', 'macos', 'fxos', 'meego', 'television', or 'unknown'</td>
+		<td>'ios', 'iphone', 'ipad', 'ipod', 'visionos', 'harmonyos', 'chromeos', 'android', 'blackberry', 'macos', 'windows', 'fxos', 'meego', 'linux', 'television', or 'unknown'</td>
 	</tr>
 </table>
 

--- a/docs/research/ua_strings.md
+++ b/docs/research/ua_strings.md
@@ -1,0 +1,22 @@
+# Research: New Device UA Strings
+
+## VisionOS
+- Apple Vision Pro (Safari): Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15
+- Note: Often indistinguishable from macOS/iPadOS desktop mode. Some versions/apps might show "XROS".
+
+## ChromeOS
+- Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36
+- Key: "CrOS"
+
+## Linux
+- Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36
+- Key: "Linux" (exclude Android, CrOS)
+
+## Game Consoles
+- PlayStation 5: Mozilla/5.0 (PlayStation; PlayStation 5/2.26) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15
+- Xbox Series X: Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox Series X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36 Edge/20.02
+- Nintendo Switch: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.10 NintendoBrowser/5.1.0.13343
+
+## Smart TVs
+- Tizen (Samsung): Mozilla/5.0 (SMART-TV; Linux; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.2 Chrome/63.0.3239.84 TV Safari/537.36
+- webOS (LG): Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 WebAppManager

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ export type DeviceOs =
   | 'meego'
   | 'television'
   | 'harmonyos'
+  | 'visionos'
+  | 'chromeos'
+  | 'linux'
   | 'unknown'
 
 export type OrientationChangeCallback = (newOrientation: 'landscape' | 'portrait') => void
@@ -37,6 +40,9 @@ export interface Device {
   fxosTablet(): boolean
   meego(): boolean
   harmonyos(): boolean
+  visionos(): boolean
+  chromeos(): boolean
+  linux(): boolean
   television(): boolean
   cordova(): boolean
   nodeWebkit(): boolean
@@ -90,7 +96,12 @@ const televisionDevices: string[] = [
   'dlnadoc',
   'pov_tv',
   'hbbtv',
-  'ce-html'
+  'ce-html',
+  'tizen',
+  'webos',
+  'playstation',
+  'xbox',
+  'nintendo'
 ]
 
 // Private Utility Functions
@@ -107,34 +118,30 @@ function find(needle: string): boolean {
 }
 
 // Check if documentElement already has a given class.
-function hasClass(className: string): RegExpMatchArray | null {
-  return documentElement.className.match(new RegExp(className, 'i'))
+function hasClass(className: string): boolean {
+  return documentElement.classList.contains(className)
 }
 
 // Add one or more CSS classes to the <html> element.
 function addClass(className: string): void {
-  let currentClassNames: string | null = null
-  if (!hasClass(className)) {
-    currentClassNames = documentElement.className.replace(/^\s+|\s+$/g, '')
-    documentElement.className = `${currentClassNames} ${className}`
-  }
+  const classNames = className.split(' ')
+  classNames.forEach((name) => {
+    if (name) {
+      documentElement.classList.add(name)
+    }
+  })
 }
 
 // Remove single CSS class from the <html> element.
 function removeClass(className: string): void {
-  if (hasClass(className)) {
-    documentElement.className = documentElement.className.replace(
-      ` ${className}`,
-      ''
-    )
-  }
+  documentElement.classList.remove(className)
 }
 
 // Main functions
 // --------------
 
 device.macos = function (): boolean {
-  return find('mac') && !device.ios()
+  return find('mac') && !device.ios() && !device.visionos()
 }
 
 device.ios = function (): boolean {
@@ -152,7 +159,7 @@ device.ipod = function (): boolean {
 device.ipad = function (): boolean {
   const iPadOS13Up =
     navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
-  return find('ipad') || iPadOS13Up
+  return (find('ipad') || iPadOS13Up) && !device.visionos()
 }
 
 device.android = function (): boolean {
@@ -211,6 +218,23 @@ device.harmonyos = function (): boolean {
   return find('harmonyos')
 }
 
+device.visionos = function (): boolean {
+  return find('xros') || (find('macintosh') && navigator.maxTouchPoints > 5)
+}
+
+device.chromeos = function (): boolean {
+  return find('cros')
+}
+
+device.linux = function (): boolean {
+  return (
+    find('linux') &&
+    !device.android() &&
+    !device.chromeos() &&
+    !device.television()
+  )
+}
+
 device.cordova = function (): boolean {
   return !!(window as Window & { cordova?: unknown }).cordova && location.protocol === 'file:'
 }
@@ -237,7 +261,8 @@ device.tablet = function (): boolean {
     device.androidTablet() ||
     device.blackberryTablet() ||
     device.windowsTablet() ||
-    device.fxosTablet()
+    device.fxosTablet() ||
+    device.visionos()
   )
 }
 
@@ -303,7 +328,11 @@ device.noConflict = function (): Device {
 
 // Insert the appropriate CSS class based on the user agent.
 
-if (device.ios()) {
+if (device.nodeWebkit()) {
+  addClass('node-webkit')
+} else if (device.television()) {
+  addClass('television')
+} else if (device.ios()) {
   if (device.ipad()) {
     addClass('ios ipad tablet')
   } else if (device.iphone()) {
@@ -313,6 +342,12 @@ if (device.ios()) {
   }
 } else if (device.macos()) {
   addClass('macos desktop')
+} else if (device.visionos()) {
+  addClass('visionos tablet')
+} else if (device.chromeos()) {
+  addClass('chromeos desktop')
+} else if (device.linux()) {
+  addClass('linux desktop')
 } else if (device.harmonyos()) {
   if (find('mobile')) {
     addClass('harmonyos mobile')
@@ -347,10 +382,6 @@ if (device.ios()) {
   }
 } else if (device.meego()) {
   addClass('meego mobile')
-} else if (device.nodeWebkit()) {
-  addClass('node-webkit')
-} else if (device.television()) {
-  addClass('television')
 } else if (device.desktop()) {
   addClass('desktop')
 }
@@ -414,18 +445,21 @@ function findMatch<T extends string>(arr: T[]): T | 'unknown' {
 
 device.type = findMatch(['mobile', 'tablet', 'desktop']) as DeviceType
 device.os = findMatch([
+  'television',
   'ios',
   'iphone',
   'ipad',
   'ipod',
+  'visionos',
   'harmonyos',
   'android',
   'blackberry',
   'macos',
   'windows',
+  'chromeos',
   'fxos',
   'meego',
-  'television'
+  'linux'
 ]) as DeviceOs
 
 function setOrientationCache(): void {

--- a/tests/ua-strings.ts
+++ b/tests/ua-strings.ts
@@ -76,6 +76,18 @@ export const uaFixtures: UAFixture[] = [
     },
   },
 
+  // === visionOS ===
+  {
+    name: 'Apple Vision Pro (Safari)',
+    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+    navigatorOverrides: { platform: 'MacIntel', maxTouchPoints: 6 },
+    expected: {
+      os: 'visionos',
+      type: 'tablet',
+      methods: { visionos: true, tablet: true, macos: false, ipad: false, ios: false },
+    },
+  },
+
   // === Android: Phones ===
   {
     name: 'Android Chrome phone',
@@ -172,18 +184,29 @@ export const uaFixtures: UAFixture[] = [
     name: 'Linux Chrome',
     ua: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
     expected: {
-      os: 'unknown',
+      os: 'linux',
       type: 'desktop',
-      methods: { desktop: true, mobile: false, tablet: false, windows: false, macos: false, android: false },
+      methods: { linux: true, desktop: true, mobile: false, tablet: false, windows: false, macos: false, android: false },
     },
   },
   {
     name: 'Linux Firefox',
     ua: 'Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0',
     expected: {
-      os: 'unknown',
+      os: 'linux',
       type: 'desktop',
-      methods: { desktop: true, mobile: false, tablet: false },
+      methods: { linux: true, desktop: true, mobile: false, tablet: false },
+    },
+  },
+
+  // === ChromeOS ===
+  {
+    name: 'ChromeOS (CrOS)',
+    ua: 'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36',
+    expected: {
+      os: 'chromeos',
+      type: 'desktop',
+      methods: { chromeos: true, desktop: true, linux: false, android: false },
     },
   },
 
@@ -191,6 +214,42 @@ export const uaFixtures: UAFixture[] = [
   {
     name: 'Smart TV (generic)',
     ua: 'Mozilla/5.0 (SMART-TV; Linux; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.2 Chrome/63.0.3239.84 TV Safari/537.36 SmartTV',
+    expected: {
+      os: 'television',
+      type: 'desktop',
+      methods: { television: true },
+    },
+  },
+  {
+    name: 'Samsung Tizen TV',
+    ua: 'Mozilla/5.0 (SMART-TV; Linux; Tizen 5.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.2 Chrome/63.0.3239.84 TV Safari/537.36',
+    expected: {
+      os: 'television',
+      type: 'desktop',
+      methods: { television: true },
+    },
+  },
+  {
+    name: 'LG webOS TV',
+    ua: 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 WebAppManager',
+    expected: {
+      os: 'television',
+      type: 'desktop',
+      methods: { television: true },
+    },
+  },
+  {
+    name: 'PlayStation 5',
+    ua: 'Mozilla/5.0 (PlayStation; PlayStation 5/2.26) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15',
+    expected: {
+      os: 'television',
+      type: 'desktop',
+      methods: { television: true },
+    },
+  },
+  {
+    name: 'Xbox Series X',
+    ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox Series X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36 Edge/20.02',
     expected: {
       os: 'television',
       type: 'desktop',


### PR DESCRIPTION
I have modernized the `current-device` library by adding support for several modern platforms and refactoring the internal DOM manipulation logic.

### Key Improvements:
1.  **VisionOS Support**: Added `device.visionos()` and related CSS classes. Refined `ipad()` and `macos()` to correctly exclude Vision Pro.
2.  **ChromeOS & Linux**: Added explicit detection for `chromeos` and `linux`.
3.  **Expanded TV & Console Detection**: Updated `televisionDevices` to include `tizen`, `webos`, `playstation`, `xbox`, and `nintendo`.
4.  **Modernized DOM Logic**: Switched from manual string/regex manipulation of `className` to the safer and more efficient `classList` API.
5.  **Improved Robustness**: Optimized the detection matching order to ensure specialized devices are correctly identified before generic categories.

Comprehensive tests have been added to verify all new detections and ensure no regressions for existing platforms.

---
*PR created automatically by Jules for task [12977527891009333807](https://jules.google.com/task/12977527891009333807) started by @matthewhudson*